### PR TITLE
set RG, REGION override with default

### DIFF
--- a/CE/appid-ce-clean-up.sh
+++ b/CE/appid-ce-clean-up.sh
@@ -15,8 +15,8 @@ export APPID_INSTANCE_NAME=cns-example-AppID-automated
 export APPID_SERVICE_KEY_NAME=cns-example-AppID-automated-service-key
 
 
-export RESOURCE_GROUP=default
-export REGION="us-south"
+export RESOURCE_GROUP=${RESOURCE_GROUP:-default}
+export REGION=${REGION:-us-south}
 export NAMESPACE=""
 
 # CE for IBM Cloud Container Registry access

--- a/CE/appid-ce-deploy-apps.sh
+++ b/CE/appid-ce-deploy-apps.sh
@@ -8,9 +8,9 @@
 
 export PROJECT_NAME=$MYPROJECT
 #export PROJECT_NAME=cloud-native-starter-ce-workshop
-export RESOURCE_GROUP=default
+export RESOURCE_GROUP=${RESOURCE_GROUP:-default}
 export REPOSITORY=tsuedbroecker
-export REGION="us-south"
+export REGION=${REGION:-us-south}
 export NAMESPACE=""
 export STATUS="Running"
 

--- a/CE/ce-create-monitoring-logging-services.sh
+++ b/CE/ce-create-monitoring-logging-services.sh
@@ -2,8 +2,8 @@
 
 # **************** Global variables
 
-export RESOURCE_GROUP=default
-export REGION="us-south"
+export RESOURCE_GROUP=${RESOURCE_GROUP:-default}
+export REGION=${REGION:-us-south}
 export SERVICE_PLAN="lite"
 export LOGANALYSIS_SERVICE_NAME="logdna"
 export YOUR_SERVICE_FOR_LOGGING="IBMLogAnalysis-code-engine"

--- a/CE/ce-deploy-apps-secret.sh
+++ b/CE/ce-deploy-apps-secret.sh
@@ -7,9 +7,9 @@
 # **************** Global variables
 
 export PROJECT_NAME=$MYPROJECT
-export RESOURCE_GROUP=default
+export RESOURCE_GROUP=${RESOURCE_GROUP:-default}
 export REPOSITORY=tsuedbroecker
-export REGION="us-south"
+export REGION=${REGION:-us-south}
 export NAMESPACE=""
 export KEYCLOAK_URL=""
 export WEBAPI_URL=""

--- a/CE/ce-deploy-apps.sh
+++ b/CE/ce-deploy-apps.sh
@@ -7,9 +7,9 @@
 # **************** Global variables
 
 export PROJECT_NAME=$MYPROJECT
-export RESOURCE_GROUP=default
+export RESOURCE_GROUP=${RESOURCE_GROUP:-default}
 export REPOSITORY=tsuedbroecker
-export REGION="us-south"
+export REGION=${REGION:-us-south}
 export NAMESPACE=""
 export KEYCLOAK_URL=""
 export WEBAPI_URL=""

--- a/CE/ce-reconfigure-keycloak.sh
+++ b/CE/ce-reconfigure-keycloak.sh
@@ -7,9 +7,9 @@
 # **************** Global variables
 
 export PROJECT_NAME=$MYPROJECT
-export RESOURCE_GROUP=default
+export RESOURCE_GROUP=${RESOURCE_GROUP:-default}
 export REPOSITORY=tsuedbroecker
-export REGION="us-south"
+export REGION=${REGION:-us-south}
 export NAMESPACE=""
 export KEYCLOAK_URL=""
 export WEBAPI_URL=""

--- a/CE/ce-remove-apps.sh
+++ b/CE/ce-remove-apps.sh
@@ -7,8 +7,8 @@
 # **************** Global variables
 
 export PROJECT_NAME=$MYPROJECT
-export RESOURCE_GROUP=default
-export REGION="us-south"
+export RESOURCE_GROUP=${RESOURCE_GROUP:-default}
+export REGION=${REGION:-us-south}
 
 # **************** Functions ****************************
 


### PR DESCRIPTION
Update shell scripts to manage deployment to use REGION and RESOURCE_GROUP environment variables if set. Otherwise default to prior behavior with `REGION=us-south` and `RESOURCE_GROUP=default`.

Avoids having users edit scripts to customize for REGION and RESOURCE_GROUP.